### PR TITLE
Fix async issue in text display

### DIFF
--- a/Codesanook.LinqToEF1010/MainWindow.cs
+++ b/Codesanook.LinqToEF1010/MainWindow.cs
@@ -36,7 +36,7 @@ namespace Codesanook.LinqToEF101
             textView1 = new TextView
             {
                 X = Pos.Center(),
-                Y = Pos.At(10),
+                Y = Pos.At(5),
                 Width = Dim.Fill(),
                 Height = 3,
                 Text = "OKay\nokay"
@@ -45,7 +45,7 @@ namespace Codesanook.LinqToEF101
             textView2 = new TextView
             {
                 X = Pos.Center(),
-                Y = Pos.Bottom(textView1),
+                Y = Pos.Bottom(textView1) + 5,
                 Width = Dim.Fill(),
                 Height = 3,
                 Text = "OKay2\nokay"
@@ -59,31 +59,45 @@ namespace Codesanook.LinqToEF101
 
         }
 
-        private async void clickAsync()
+        private void clickAsync() => Task.Run(async () =>
         {
-
+            var output1 = new StringBuilder();
+            var output2 = new StringBuilder();
 
             var task1 = ExecuteTransaction(
                 IsolationLevel.ReadCommitted,
                 (query) =>
                 {
-                    var keyEvent = new KeyEvent(Key.Esc);
-                    button.ProcessKey(keyEvent);
-                    textView1.Text += "\n" + query;
+                    Application.MainLoop.Invoke(() =>
+                    {
+                        output1.AppendLine(query);
+                        textView1.Text = output1.ToString();
+                    });
                 },
                 "UPDATE StudentMarks SET marksObtained = 90 WHERE deptId = 101 AND examId = 201",
                 "UPDATE Exam SET examDesc = 'Theory Paper and Lab Assignmnet in Data Structure' WHERE examId = 201",
                 "UPDATE StudentMarks SET marksObtained = 70 --80 WHERE deptId = 101 AND examId = 201"
             );
 
-            //var task2 = ExecuteTransaction(
-            //    textView2,
-            //    IsolationLevel.ReadCommitted,
-            //    "SELECT marksObtained FROM StudentMarks WHERE deptId = 101 AND examId = 201 AND studentId = 1"
-            //);
+            var task2 = Task.Run(async () =>
+            {
+                await Task.Delay(500);
+                await ExecuteTransaction(
+                    IsolationLevel.ReadCommitted,
+                    (query) =>
+                    {
+                        Application.MainLoop.Invoke(() =>
+                        {
+                            output2.AppendLine(query);
+                            textView2.Text = output2.ToString();
+                        });
+                    },
+                    "SELECT marksObtained FROM StudentMarks WHERE deptId = 101 AND examId = 201 AND studentId = 1"
+                );
+            });
 
-            await Task.WhenAll(task1);
-        }
+            await Task.WhenAll(task1, task2);
+        });
 
         private async Task ExecuteTransaction(IsolationLevel isolationLevel, Action<string> action, params string[] queries)
         {
@@ -97,7 +111,7 @@ namespace Codesanook.LinqToEF101
             foreach (var query in queries)
             {
                 var command = new SqlCommand(query, connection, (SqlTransaction)transaction);
-                await Task.Delay(100);
+                await Task.Delay(1000);
                 await command.ExecuteNonQueryAsync();
                 action(query);
             }


### PR DESCRIPTION
Gui.cs is apparently doing it's own async message pumping, and the messages only get pumped when there's some external event (e.g. mouse moving over the console window). To fix this, we use Task.Run to move the task to the thread pool, and the `Application.MainLoop.Invoke` API to move the screen updates back to the UI thread.

Also updated the timings to expose the locking better.